### PR TITLE
article_like model の追加

### DIFF
--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,4 +1,4 @@
-class UserLike < ApplicationRecord
+class ArticleLike < ApplicationRecord
   belongs_to :user
   belongs_to :article
 end

--- a/db/migrate/20211122072622_create_article_likes.rb
+++ b/db/migrate/20211122072622_create_article_likes.rb
@@ -1,6 +1,6 @@
-class CreateUserLikes < ActiveRecord::Migration[6.0]
+class CreateArticleLikes < ActiveRecord::Migration[6.0]
   def change
-    create_table :user_likes do |t|
+    create_table :article_likes do |t|
       t.references :user, null: false, foreign_key: true
       t.references :article, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_22_041549) do
+ActiveRecord::Schema.define(version: 2021_11_22_072622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "article_likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_article_likes_on_article_id"
+    t.index ["user_id"], name: "index_article_likes_on_user_id"
+  end
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
@@ -32,15 +41,6 @@ ActiveRecord::Schema.define(version: 2021_11_22_041549) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["article_id"], name: "index_comments_on_article_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
-  end
-
-  create_table "user_likes", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "article_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["article_id"], name: "index_user_likes_on_article_id"
-    t.index ["user_id"], name: "index_user_likes_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -68,9 +68,9 @@ ActiveRecord::Schema.define(version: 2021_11_22_041549) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "article_likes", "articles"
+  add_foreign_key "article_likes", "users"
   add_foreign_key "articles", "users"
   add_foreign_key "comments", "articles"
   add_foreign_key "comments", "users"
-  add_foreign_key "user_likes", "articles"
-  add_foreign_key "user_likes", "users"
 end

--- a/spec/factories/user_likes.rb
+++ b/spec/factories/user_likes.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :user_like do
-    user { nil }
-    article { nil }
-  end
-end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ArticleLike, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/user_like_spec.rb
+++ b/spec/models/user_like_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe UserLike, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
## 変更の概要

* user_like  tabel と model を article_like model に変更
* relation を設定

## 変更の内容
* tabel の名前を間違えていたため

## 実行コマンド

* bundle exec rails db:rollback
* bundle exec rails  model UserLike user:references article:references
* bundle exec rails g model ArticleLike user:references article:references
* bundle exec rails db:migrate
* bundle exec rubocop

## 実行結果

 * [x] db:rollback をしてmigration をもとに戻す
 * [x] user_like を削除
 * [x] article_like の追加 
 * [x] db:migrate で schema.rb に記述を追加