### PR TITLE
記事一覧の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < Api::V1::BaseApiController
+  def index
+    articles = Article.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -60,3 +60,9 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Max: 10
+
+RSpec/LetSetup:
+  Enabled: false

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -4,17 +4,18 @@ RSpec.describe "Articles", type: :request do
   describe "GET /api/v1/articles" do
     subject { get(api_v1_articles_path) }
 
-    context "3つの記事一覧を取得するとき" do
+    context "3つの記事を作成するとき" do
       let!(:article1) { create(:article, updated_at: 1.day.ago) }
       let!(:article2) { create(:article, updated_at: 2.day.ago) }
       let!(:article3) { create(:article) }
 
-      fit "記事一覧を更新順で取得できる" do
+      it "記事一覧を取得できる" do
         subject
         res = JSON.parse(response.body)
 
         expect(res.length).to eq 3
         expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Articles", type: :request do
+  describe "GET /api/v1/articles" do
+    subject { get(api_v1_articles_path) }
+
+    context "3つの記事一覧を取得するとき" do
+      let!(:article1) { create(:article, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, updated_at: 2.day.ago) }
+      let!(:article3) { create(:article) }
+
+      fit "記事一覧を更新順で取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(res.length).to eq 3
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

* 記事一覧を json で返す機能の実装
* request spec の実装

## 詳細

* `articles_contoller`に index メソッドの記述の追加
* `article_preview_serializer.rb` の作成
* `article_preview_serializer.rb` に紐付いた `user_serializer.rb` の作成
* `request spec` にテストの記述
* rubocop の設定変更

## やったこと

* テスト実装
   => bundle exec rspec 
* `rubocop/rspec.yml` の設定のエラーの記述を変更した
   => RSpec/MultipleExpectations:  Max: 10
   => RSpec/LetSetup:  Enabled: false
