### PR TITLE
記事作成の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,4 +8,15 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
     article = Article.find(params[:id])
     render json: article, serializer: Api::V1::ArticleSerializer
   end
+
+  def create
+    article = current_user.articles.create!(article_params)
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+
+  private
+
+    def article_params
+      params.require(:article).permit(:title, :body)
+    end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,7 @@ module WonderfulEditor
     end
 
     config.api_only = true
-
+    config.middleware.use ActionDispatch::Flash
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -49,4 +49,32 @@ RSpec.describe "Articles", type: :request do
       end
     end
   end
+
+  describe "POST /api/v1/articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    context "ログインユーザーが適切なパラメーターを送信したとき" do
+      let(:params) { { article: attributes_for(:article) } }
+      let(:current_user) { create(:user) }
+      # rubocop:disable RSpec/AnyInstance
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      # rubocop:enable RSpec/AnyInstance
+
+      it "記事のレコードが作成できる" do
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ログインユーザーがいないとき" do
+      let(:params) { { article: attributes_for(:article) } }
+
+      it "エラーする" do
+        expect { subject }.to raise_error(NoMethodError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

* ログインしているユーザーができる記事作成の実装

## やったこと

* `base_api_controller.rb`に current_user メソッドを定義
  => current_user に users テーブルの一番初めのユーザー（User.frist）を定義
*  `articles_controller.rb` に create メソッドの定義
  => articles テーブルに 定義した current_user を紐付けてcreate メソッドを作成
* `articles_spec.rb` に テストを実装
  => ダミーデータとして current_user を呼び出すようにして article のテスト実装をする

## 補足

* CSRF 対策を OFF にする記述と500のエラーがが発生するので直す記述を追加