### PR TITLE
記事更新の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -14,6 +14,12 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
     render json: article, serializer: Api::V1::ArticleSerializer
   end
 
+  def update
+    article = current_user.articles.find(params[:id])
+    article.update!(article_params)
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+
   private
 
     def article_params

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,6 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  RSpec::Matchers.define_negated_matcher :not_change, :change
 end


### PR DESCRIPTION
## 概要

* ログインしているユーザーができる記事更新の実装

## やったこと

* `articles_controller.rb`に update メソッドを定義
  => current_user に紐付いた記事更新ができるように実装
*  `articles_spec.rb` テストを定義
  => ログインしているユーザーだけが記事の更新ができるようにダミーデータで実装
* `spec_helper.rb`にカスタム matcher を実装
  => change  の否定系の not_change matcher をカスタム
