### PR TITLE
記事削除の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -20,6 +20,11 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
     render json: article, serializer: Api::V1::ArticleSerializer
   end
 
+  def destroy
+    article = current_user.articles.find(params[:id])
+    article.destroy!
+  end
+
   private
 
     def article_params


### PR DESCRIPTION
## 概要

* ログインしているユーザーができる記事削除の実装

## やったこと

* `articles_controller.rb`に destroy メソッドを定義
  => current_user に紐付いた記事削除ができるように実装
*  `articles_spec.rb` テストを定義
  => ログインしているユーザーだけが記事の削除ができるようにダミーデータで実装