### PR TITLE
既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::BaseApiController
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
+
   def index
     articles = Article.order(updated_at: :desc)
     render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :current_user, :current_api_v1_user
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe "Articles", type: :request do
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-
     context "ログインユーザーが記事のレコードを更新しようとしたとき" do
       let(:article_id) { article.id }
       let(:article) { create(:article, user: current_user) }
@@ -111,7 +110,6 @@ RSpec.describe "Articles", type: :request do
 
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
-
 
     context "ログインユーザーが記事のレコードを削除しようとしたとき" do
       let(:article_id) { article.id }

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -51,14 +51,12 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "ログインユーザーが適切なパラメーターを送信したとき" do
       let(:params) { { article: attributes_for(:article) } }
+      let(:headers) { current_user.create_new_auth_token }
       let(:current_user) { create(:user) }
-      # rubocop:disable RSpec/AnyInstance
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-      # rubocop:enable RSpec/AnyInstance
 
       it "記事のレコードが作成できる" do
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -73,20 +71,19 @@ RSpec.describe "Articles", type: :request do
       let(:params) { { article: attributes_for(:article) } }
 
       it "エラーする" do
-        expect { subject }.to raise_error(NoMethodError)
+        subject
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
 
   describe "PATCH /api/v1/article/:id" do
-    subject { patch(api_v1_article_path(article_id), params: params) }
+    subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article), created_at: 1.day.ago } }
     let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
 
-    # rubocop:disable RSpec/AnyInstance
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-    # rubocop:enable RSpec/AnyInstance
 
     context "ログインユーザーが記事のレコードを更新しようとしたとき" do
       let(:article_id) { article.id }
@@ -110,13 +107,11 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "DELETE /api/v1/article/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
     let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
 
-    # rubocop:disable RSpec/AnyInstance
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-    # rubocop:enable RSpec/AnyInstance
 
     context "ログインユーザーが記事のレコードを削除しようとしたとき" do
       let(:article_id) { article.id }


### PR DESCRIPTION
## 概要

* 既存の articles_controller, base_api_conrtoller, articles_spec の修正

## 詳細

* devise_token_auth のヘルパーメソッド をエイリアスで使えるようにする。
* authenticate_user! を実装
* テストでログインが必要な API を叩く際に headers を渡すように実装

