### PR TITLE
Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,4 +3,5 @@ class Article < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   validates :title, presence: true, length: { maximum: 15 }
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20211120123032_devise_token_auth_create_users.rb
+++ b/db/migrate/20211120123032_devise_token_auth_create_users.rb
@@ -29,7 +29,6 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
 
       ## User Info
       t.string :name
-      t.string :nickname
       t.string :image
       t.string :email
 

--- a/db/migrate/20211216011947_add_status_to_articles.rb
+++ b/db/migrate/20211216011947_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_22_072622) do
+ActiveRecord::Schema.define(version: 2021_12_16_011947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_11_22_072622) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
@@ -56,7 +57,6 @@ ActiveRecord::Schema.define(version: 2021_11_22_072622) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "name"
-    t.string "nickname"
     t.string "image"
     t.string "email"
     t.json "tokens"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,4 +4,12 @@ FactoryBot.define do
     body { Faker::Lorem.sentence }
     user
   end
+
+  trait :draft do
+    status { :draft }
+  end
+
+  trait :published do
+    status { :published }
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,18 +1,27 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  # pending "add some examples to (or delete) #{__FILE__}"
-  context "title, body が作成される時" do
+  context "title, body が作成されるとき" do
     let(:article) { build(:article) }
-    it "記事が作成される" do
+    it "下書き状態のが作成できる" do
       expect(article).to be_valid
+      expect(article.status).to eq "draft"
     end
   end
 
-  context "title がない時" do
-    let(:article) { build(:article, title: nil) }
-    it "エラーする" do
-      expect(article).not_to be_valid
+  context "status が下書き状態のとき" do
+    let(:article) { build(:article, :draft) }
+    it "記事を下書き状態で作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "status が公開状態のとき" do
+    let(:article) { build(:article, :published) }
+    it "記事を公開状態で作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "published"
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  # pending "add some examples to (or delete) #{__FILE__}"
   context " name, email, password を指定している時 " do
     let(:user) { build(:user) }
     it " ユーザーが作られる " do
@@ -13,7 +12,6 @@ RSpec.describe User, type: :model do
     let(:user) { build(:user, name: nil) }
     it "エラーする" do
       expect(user).not_to be_valid
-      # binding.pry
     end
   end
 end


### PR DESCRIPTION
## 概要

* Article model に 下書きと公開の enum を追加
* Article model  のテスト実装

## 詳細

* status カラムの migration ファイルを作成
* `app/models/article.rb` に enum を設定
* `spec/factories/articles.rb` に下書きと公開の trait を設定
* 下書き状態のときと公開状態のときのテストを実装

## 補足

* いらないコメントアウトをリファクタリング
* `20211120123032_devise_token_auth_create_users.rb` からnicknameカラムを削除