### PR TITLE
既存のAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,24 +2,24 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.order(updated_at: :desc)
+    articles = Article.published.order(updated_at: :desc)
     render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
   end
 
   def show
-    article = Article.find(params[:id])
-    render json: article, serializer: Api::V1::ArticleSerializer
+    article = Article.published.find(params[:id])
+    render json: article
   end
 
   def create
     article = current_user.articles.create!(article_params)
-    render json: article, serializer: Api::V1::ArticleSerializer
+    render json: article
   end
 
   def update
     article = current_user.articles.find(params[:id])
     article.update!(article_params)
-    render json: article, serializer: Api::V1::ArticleSerializer
+    render json: article
   end
 
   def destroy
@@ -30,6 +30,6 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   private
 
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user, serializer: Api::V1::UserSerializer
 end


### PR DESCRIPTION
## 概要

* 既存の記事に関する API とそのテスト修正
  
## 詳細

* 公開記事だけを取得できるように修正
* 記事作成は記事の公開/非公開を選択できるように修正
* `app/serializers/api/v1/article_serializer.rb`に status を追加