### PR TITLE
下書き記事の一覧/詳細 のAPI実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::Articles::DraftsController < Api::V1::BaseApiController
+  before_action :authenticate_user!
+
+  def index
+    articles = current_user.articles.draft.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+
+  def show
+    article = current_user.articles.draft.find(params[:id])
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  let(:headers) { current_user.create_new_auth_token }
+  let(:current_user) { create(:user) }
+
+  describe "GET api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    context "記事を作成するとき" do
+      let!(:article1) { create(:article, :draft, user: current_user) }
+      let!(:article2) { create(:article, :draft, user: current_user) }
+      let!(:article3) { create(:article, :draft) }
+
+      it "下書き状態の記事一覧を取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(res.length).to eq 2
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET api/v1/articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    context "指定した id の記事が存在して" do
+      let(:article_id) { article.id }
+
+      context "対象の記事が下書き状態のとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+        # rubocop:disable RSpec/ExampleLength
+        it "その記事の詳細を取得できる" do
+          # rubocop:enable RSpec/ExampleLength
+          subject
+          res = JSON.parse(response.body)
+
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["status"]).to eq article.status
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "対象の記事が他のユーザーが書いた下書きのとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が取得できない" do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

* 下書き記事の一覧/詳細 の API とテスト実装

## 詳細

* 下書きのためのルーティングを記述
* 下書き記事の controller の作成
* 下書き記事のテスト実装
