### PR TITLE
自分が書いた記事一覧の取得

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Current::ArticlesController < Api::V1::BaseApiController
+  before_action :authenticate_user!
+
+  def index
+    articles = current_user.articles.published.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+      namespace :current do
+        resources :articles, only: :index
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  let(:headers) { current_user.create_new_auth_token }
+  let(:current_user) { create(:user) }
+
+  describe "GET api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    context "複数の記事が存在するとき" do
+      let!(:article1) { create(:article, :published, user: current_user, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, :published, user: current_user, updated_at: 2.day.ago) }
+      let!(:article3) { create(:article, :published, user: current_user) }
+
+      before do
+        create(:article, :draft, user: current_user)
+        create(:article, :published)
+      end
+
+      it "自分の公開記事を更新順に取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(res.length).to eq 3
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

* 自分が書いた記事一覧のための API とそのテスト実装

## 詳細

* `routes.rb`にルーティングを追加
* `app/controllers/api/v1/current/articles_controller.rb`を作成
  * 公開記事一覧を取得できるように API の実装
* 自分が書いた公開記事が取得できるようにテストを実装
